### PR TITLE
fix(scrape): restore downloading album by slug

### DIFF
--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -23,8 +23,8 @@ func DownloadPage(url string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode != 200 {
-		return nil, err
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received a non-200 status code: %d", res.StatusCode)
 	}
 	return res, err
 }
@@ -63,17 +63,19 @@ func RetrieveAlbum(path string) (types.Album, error) {
 	var album types.Album
 	slugBits := strings.Split(path, "/")
 	album.Slug = slugBits[len(slugBits)-1]
-	albumUrl := fmt.Sprintf("%s%s", util.SiteBase, path)
+	albumUrl := fmt.Sprintf("%s/game-soundtracks/album/%s", util.SiteBase, path)
+
 	res, err := DownloadPage(albumUrl)
+	if err != nil {
+		return album, err
+	}
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
 		if err != nil {
 			panic(err)
 		}
 	}(res.Body)
-	if err != nil {
-		return album, err
-	}
+
 	doc, err := goquery.NewDocumentFromReader(res.Body)
 	if err != nil {
 		return album, err


### PR DESCRIPTION
The feature to download by slug was broken in the rewrite, any attempt
to use it would crash with a memory exception when attempting to read a
member of a nil http.Response.

The DownloadPage function violates the invariant that an
http.Client.Do-like function would return one of http.Response or error
by returning nil for both if the server returned non-200 status codes.

This changeset modifies RetrieveAlbum to construct the proper album URL,
and handles an error response from DownloadPage before attempting to
defer closing the body. DownloadPage itself is modified to return an
error if an unexpected status is received.