### PR TITLE
Fix up broken downloads when using search

### DIFF
--- a/cmd/khinsider/search.go
+++ b/cmd/khinsider/search.go
@@ -8,6 +8,7 @@ import (
 	"github.com/marcus-crane/khinsider/v2/pkg/search"
 	"github.com/marcus-crane/khinsider/v2/pkg/update"
 	"github.com/pterm/pterm"
+	"strings"
 )
 
 func BeforeSearch() error {
@@ -53,6 +54,17 @@ func DownloadAction(albumSlug string) error {
 	if albumSlug == "" {
 		pterm.Error.Println("Please enter the slug for a valid album")
 		return errors.New("no album slug provided")
+	}
+	// At present, the index captures entries as URL paths so eg;
+	// /game-soundtrack/album/<slug> whereas the user downloads
+	// and album by providing just the slug. We could update the
+	// index to just save slugs but this would break compatibility
+	// with earlier versions so instead we just strip the index
+	// entries down to their slug. Both searching and direct slug
+	// download pass through this function so they need to be consistent
+	if strings.Contains(albumSlug, "/") {
+		slugBits := strings.Split(albumSlug, "/")
+		albumSlug = slugBits[len(slugBits)-1]
 	}
 	album, err := scrape.RetrieveAlbum(albumSlug)
 	if err != nil {

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -59,11 +59,10 @@ func GetResultsForLetter(letter string) (types.SearchResults, error) {
 	return results, nil
 }
 
-func RetrieveAlbum(path string) (types.Album, error) {
+func RetrieveAlbum(slug string) (types.Album, error) {
 	var album types.Album
-	slugBits := strings.Split(path, "/")
-	album.Slug = slugBits[len(slugBits)-1]
-	albumUrl := fmt.Sprintf("%s/game-soundtracks/album/%s", util.SiteBase, path)
+	album.Slug = slug
+	albumUrl := fmt.Sprintf("%s/game-soundtracks/album/%s", util.SiteBase, slug)
 
 	res, err := DownloadPage(albumUrl)
 	if err != nil {


### PR DESCRIPTION
Both the `search` and `album` commands ultimately use the `album` command to download albums by providing a slug but there was an inconsistency between them.

In short, the index saves URL paths eg `/game-soundtrack/album/<slug>` and passes the one matching a search result into the `album` command.

The `album` command receives a slug by itself though so due to this mismatch, only one of the commands was working.

This PR resolves the inconsistency by stripping input from the `search` command down to just a slug and then builds up the proper URL internally.

I would have just updated the index to store plain slugs but doing so would break any users on an earlier version of `khinsider 2.x`