### PR TITLE
Gracefully (and silently) fail if rate limited by Github API

### DIFF
--- a/cmd/khinsider/update.go
+++ b/cmd/khinsider/update.go
@@ -14,8 +14,7 @@ func isUpdaterDisabled() bool {
 }
 
 func CheckForUpdates(c *cli.Context, currentVersion string, prerelease bool) (bool, string) {
-	// TODO: Fix for go install which doesn't honour ldflags it seems?
-	if isUpdaterDisabled() && c.Command.Name != "update" || currentVersion == "dev" {
+	if isUpdaterDisabled() && c.Command.Name != "update" {
 		pterm.Debug.Println("Updater is disabled. Skipping update check.")
 		return false, ""
 	}
@@ -26,6 +25,10 @@ func CheckForUpdates(c *cli.Context, currentVersion string, prerelease bool) (bo
 	} else {
 		pterm.Debug.Printfln("Found remote prerelease version: %s", remoteVersion)
 		remoteVersion = update.GetRemoteAppPrerelease()
+	}
+	if remoteVersion == "" {
+		// Assume we were rate limited so skip update check for now
+		return false, remoteVersion
 	}
 	isUpdateAvailable := update.IsRemoteVersionNewer(currentVersion, remoteVersion)
 	pterm.Debug.Printfln("Current is %s while remote is %s. Update is available: %t", currentVersion, remoteVersion, isUpdateAvailable)


### PR DESCRIPTION
It can happen that the user is rate limited by Github when checking for updates (the unauthenticated limit is 60 calls per 15 minutes) so this command silently bails out if we hit that limit.

The proper fix here is to move the version information out of Github to a domain I control so users can hit it as often as they like but this works for now.