### PR TITLE
Fix autoupdater + add an explicit flag to disable updates

### DIFF
--- a/cmd/khinsider/main.go
+++ b/cmd/khinsider/main.go
@@ -40,7 +40,17 @@ func Execute(buildInfo BuildInfo) {
 		},
 		Usage: "easily fetch videogame soundtracks from downloads.khinsider.com",
 		Flags: []cli.Flag{
-			&cli.BoolFlag{Name: "debug", Aliases: []string{"d"}},
+			&cli.BoolFlag{
+				Name:    "debug",
+				Aliases: []string{"d"},
+			},
+			&cli.BoolFlag{
+				Name:    "no-updates",
+				Aliases: []string{"n"},
+				Value:   false,
+				Usage:   "Disable checks for updates to khinsider (env: KHINSIDER_NO_UPDATE)",
+				EnvVars: []string{"CI", "KHINSIDER_NO_UPDATE"},
+			},
 		},
 		Before: func(c *cli.Context) error {
 			if c.Bool("debug") {

--- a/cmd/khinsider/update.go
+++ b/cmd/khinsider/update.go
@@ -4,18 +4,17 @@ import (
 	"github.com/marcus-crane/khinsider/v2/internal/updater"
 	"github.com/pterm/pterm"
 	"github.com/urfave/cli/v2"
-	"os"
 	"strings"
 
 	"github.com/marcus-crane/khinsider/v2/pkg/update"
 )
 
-func isUpdaterDisabled() bool {
-	return os.Getenv("CI") == "true" || os.Getenv("KHINSIDER_NO_UPDATE") == "true"
+func isUpdaterDisabled(c *cli.Context) bool {
+	return c.Bool("no-updates")
 }
 
 func CheckForUpdates(c *cli.Context, currentVersion string, prerelease bool) (bool, string) {
-	if isUpdaterDisabled() && c.Command.Name != "update" || strings.Contains(currentVersion, "-DEV") {
+	if isUpdaterDisabled(c) && c.Command.Name != "update" || strings.Contains(currentVersion, "-DEV") {
 		pterm.Debug.Println("Updater is disabled. Skipping update check.")
 		return false, ""
 	}
@@ -42,7 +41,7 @@ func CheckForUpdates(c *cli.Context, currentVersion string, prerelease bool) (bo
 func UpdateAction(c *cli.Context, currentVersion string, prerelease bool) error {
 	releaseAvailable, remoteVersion := CheckForUpdates(c, currentVersion, prerelease)
 	pterm.Debug.Printfln("Release is available: %t. Remote version is %s", releaseAvailable, remoteVersion)
-	if !releaseAvailable && !isUpdaterDisabled() {
+	if !releaseAvailable && !isUpdaterDisabled(c) {
 		pterm.Info.Printfln("Sorry, no updates are available. The latest version is %s and you're on %s", remoteVersion, currentVersion)
 		return nil
 	}

--- a/cmd/khinsider/update.go
+++ b/cmd/khinsider/update.go
@@ -41,8 +41,15 @@ func CheckForUpdates(c *cli.Context, currentVersion string, prerelease bool) (bo
 func UpdateAction(c *cli.Context, currentVersion string, prerelease bool) error {
 	releaseAvailable, remoteVersion := CheckForUpdates(c, currentVersion, prerelease)
 	pterm.Debug.Printfln("Release is available: %t. Remote version is %s", releaseAvailable, remoteVersion)
+	if strings.Contains(currentVersion, "-DEV") {
+		pterm.Error.Println("You can't run updates when running a dev build")
+		return nil
+	}
 	if !releaseAvailable && !isUpdaterDisabled(c) {
 		pterm.Info.Printfln("Sorry, no updates are available. The latest version is %s and you're on %s", remoteVersion, currentVersion)
+		return nil
+	}
+	if isUpdaterDisabled(c) {
 		return nil
 	}
 	return updater.UpgradeInPlace(c.App.Writer, c.App.ErrWriter, remoteVersion)

--- a/cmd/khinsider/update.go
+++ b/cmd/khinsider/update.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/urfave/cli/v2"
 	"os"
+	"strings"
 
 	"github.com/marcus-crane/khinsider/v2/pkg/update"
 )
@@ -14,7 +15,7 @@ func isUpdaterDisabled() bool {
 }
 
 func CheckForUpdates(c *cli.Context, currentVersion string, prerelease bool) (bool, string) {
-	if isUpdaterDisabled() && c.Command.Name != "update" {
+	if isUpdaterDisabled() && c.Command.Name != "update" || strings.Contains(currentVersion, "-DEV") {
 		pterm.Debug.Println("Updater is disabled. Skipping update check.")
 		return false, ""
 	}

--- a/cmd/khinsider/update.go
+++ b/cmd/khinsider/update.go
@@ -43,6 +43,7 @@ func UpdateAction(c *cli.Context, currentVersion string, prerelease bool) error 
 	pterm.Debug.Printfln("Release is available: %t. Remote version is %s", releaseAvailable, remoteVersion)
 	if !releaseAvailable && !isUpdaterDisabled() {
 		pterm.Info.Printfln("Sorry, no updates are available. The latest version is %s and you're on %s", remoteVersion, currentVersion)
+		return nil
 	}
 	return updater.UpgradeInPlace(c.App.Writer, c.App.ErrWriter, remoteVersion)
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -5,34 +5,24 @@ package updater
 
 import (
 	"fmt"
+	"github.com/cli/safeexec"
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
-	"strings"
-
-	"github.com/cli/safeexec"
 )
 
 func isUnderHomebrew() bool {
-	khinsiderBinary, err := os.Executable()
-	if err != nil {
-		return false
-	}
-
 	brewExe, err := safeexec.LookPath("brew")
 	if err != nil {
 		return false
 	}
 
-	brewPrefixBytes, err := exec.Command(brewExe, "--prefix").Output()
+	_, err = exec.Command(brewExe, "list", "khinsider").Output()
 	if err != nil {
 		return false
 	}
-
-	brewBinPrefix := filepath.Join(strings.TrimSpace(string(brewPrefixBytes)), "bin") + string(filepath.Separator)
-	return strings.HasPrefix(khinsiderBinary, brewBinPrefix)
+	return true
 }
 
 func updateCommand(version string) string {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -19,10 +19,7 @@ func isUnderHomebrew() bool {
 	}
 
 	_, err = exec.Command(brewExe, "list", "khinsider").Output()
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func updateCommand(version string) string {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -16,7 +16,7 @@ import (
 )
 
 func isUnderHomebrew() bool {
-	flyBinary, err := os.Executable()
+	khinsiderBinary, err := os.Executable()
 	if err != nil {
 		return false
 	}
@@ -32,13 +32,13 @@ func isUnderHomebrew() bool {
 	}
 
 	brewBinPrefix := filepath.Join(strings.TrimSpace(string(brewPrefixBytes)), "bin") + string(filepath.Separator)
-	return strings.HasPrefix(flyBinary, brewBinPrefix)
+	return strings.HasPrefix(khinsiderBinary, brewBinPrefix)
 }
 
 func updateCommand(version string) string {
 	switch {
 	case isUnderHomebrew():
-		return "brew upgrade khinsider"
+		return "brew update && brew install marcus-crane/tap/khinsider"
 	case runtime.GOOS == "windows":
 		cmd := "iwr https://utf9k.net/khinsider/install.ps1 -useb | iex"
 		if version != "" {

--- a/main.go
+++ b/main.go
@@ -1,22 +1,22 @@
 package main
 
 import (
-	"github.com/marcus-crane/khinsider/v2/cmd/khinsider"
+  "github.com/marcus-crane/khinsider/v2/cmd/khinsider"
 )
 
 var (
-	version = "v2.0.4-DEV"
-	commit  = "n/a"
-	date    = "n/a"
-	builtBy = "dev"
+  version = "v2.0.4"
+  commit  = "n/a"
+  date    = "n/a"
+  builtBy = "dev"
 )
 
 func main() {
-	buildInfo := khinsider.BuildInfo{
-		Version: version,
-		Commit:  commit,
-		Date:    date,
-		BuiltBy: builtBy,
-	}
-	khinsider.Execute(buildInfo)
+  buildInfo := khinsider.BuildInfo{
+    Version: version,
+    Commit:  commit,
+    Date:    date,
+    BuiltBy: builtBy,
+  }
+  khinsider.Execute(buildInfo)
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	version = "dev"
+	version = "v2.0.4-DEV"
 	commit  = "n/a"
 	date    = "n/a"
 	builtBy = "dev"

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ var (
 	version = "v2.0.4"
 	commit  = "n/a"
 	date    = "n/a"
-	builtBy = "go install"
+	builtBy = "source"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,22 +1,22 @@
 package main
 
 import (
-  "github.com/marcus-crane/khinsider/v2/cmd/khinsider"
+	"github.com/marcus-crane/khinsider/v2/cmd/khinsider"
 )
 
 var (
-  version = "v2.0.4"
-  commit  = "n/a"
-  date    = "n/a"
-  builtBy = "dev"
+	version = "v2.0.4"
+	commit  = "n/a"
+	date    = "n/a"
+	builtBy = "go install"
 )
 
 func main() {
-  buildInfo := khinsider.BuildInfo{
-    Version: version,
-    Commit:  commit,
-    Date:    date,
-    BuiltBy: builtBy,
-  }
-  khinsider.Execute(buildInfo)
+	buildInfo := khinsider.BuildInfo{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+		BuiltBy: builtBy,
+	}
+	khinsider.Execute(buildInfo)
 }


### PR DESCRIPTION
This PR fixes the self updater by embedded versioning information inside the app in order to support `go install` users.

It also better works with Homebrew by calling `brew update` to ensure the latest updates are picked up

Closes: #11 #10 