### PR TITLE
Update version string

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	version = "v2.0.4"
+	version = "v2.0.6"
 	commit  = "n/a"
 	date    = "n/a"
 	builtBy = "source"

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	version = "v2.0.6"
+	version = "v2.0.7"
 	commit  = "n/a"
 	date    = "n/a"
 	builtBy = "source"


### PR DESCRIPTION
The current version string is `2.0.4`, and seems to therefore be triggering requests to update even on the latest version, `2.0.6`.